### PR TITLE
Provide better example of limit per region.

### DIFF
--- a/doc_source/ebs-fast-snapshot-restore.md
+++ b/doc_source/ebs-fast-snapshot-restore.md
@@ -2,7 +2,7 @@
 
 Amazon EBS fast snapshot restore enables you to create a volume from a snapshot that is fully\-initialized at creation\. This eliminates the latency of I/O operations on a block when it is accessed for the first time\. Volumes created using fast snapshot restore instantly deliver all of their provisioned performance\.
 
-To use fast snapshot restore, enable it for specific snapshots in specific Availability Zones\. You can enable fast snapshot restore for up to five snapshots per Region\.
+To use fast snapshot restore, enable it for specific snapshots in specific Availability Zones\. You can enable fast snapshot restore for up to five snapshots/AZs per Region\.  For example if you enable fast snapshot restore for a snapshot across 3 AZs, that counts as 3 uses of fast snapshot restore out of your 5 for the region\.
 
 **Topics**
 + [Fast Snapshot Restore States](#fsr-states)


### PR DESCRIPTION
*Issue #, if available:*
The current description of how the per region limits for EBS fast snapshot restore works is not entirely correct or clear.
*Description of changes:*
Adapt the wording and provide an example to explain that the limit is 5 against snapshot x number of AZs the feature is enabled in.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
